### PR TITLE
Adding spec for capturing remote DOI error

### DIFF
--- a/lib/hydra/remote_identifier/remote_services/doi.rb
+++ b/lib/hydra/remote_identifier/remote_services/doi.rb
@@ -50,7 +50,7 @@ module Hydra::RemoteIdentifier
         matched_data = /\Asuccess:(.*)(?<doi>doi:[^\|]*)(.*)\Z/.match(response.body)
         matched_data[:doi].strip
       rescue RestClient::Exception => e
-        raise(RemoteServiceError.new(e, uri_for_create, payload))
+        raise(RemoteServiceError.new(e, uri_for_create, data))
       end
 
       def data_for_create(payload)

--- a/spec/lib/hydra/remote_identifier/remote_services/doi_spec.rb
+++ b/spec/lib/hydra/remote_identifier/remote_services/doi_spec.rb
@@ -25,6 +25,13 @@ module Hydra::RemoteIdentifier
         it 'should post to remote service', VCR::SpecSupport(cassette_name: 'doi-create') do
           expect(subject.call(payload)).to eq(expected_doi)
         end
+
+        it 'should raise RemoteServiceError when request was invalid' do
+          RestClient.should_receive(:post).and_raise(RestClient::Exception.new)
+          expect {
+            subject.call(payload)
+          }.to raise_error(RemoteServiceError)
+        end
       end
 
       context '.remote_uri_for' do


### PR DESCRIPTION
In the event that you are attempting to mint a DOI
And you receive some remote service exception (i.e. invalid data)
Transform the exception into something meaningful

And more importantly make sure to use :data instead of :payload
as :payload is not defined within that context.
